### PR TITLE
Feat/10 로그인/회원가입 페이지 UI 반응형 작업

### DIFF
--- a/app/_components/common/Input/EmailInput.tsx
+++ b/app/_components/common/Input/EmailInput.tsx
@@ -5,6 +5,7 @@ interface EmailInputProps extends ComponentProps<typeof Input> {
   onValidate?: (value: string) => string | undefined; // 추가 유효성 검사 함수
   error?: boolean; // 외부에서 전달하는 에러 상태
   errorMessage?: string; // 외부에서 전달하는 에러 메시지
+  className?: string;
 }
 
 const EmailInput: React.FC<EmailInputProps> = ({
@@ -16,6 +17,7 @@ const EmailInput: React.FC<EmailInputProps> = ({
   onValidate,
   error: externalError,
   errorMessage: externalErrorMessage,
+  className,
 }) => {
   const [internalError, setInternalError] = useState<string | undefined>(
     undefined,
@@ -56,6 +58,7 @@ const EmailInput: React.FC<EmailInputProps> = ({
         error={finalError}
         errorMessage={finalErrorMessage}
         isAllowSpace={false}
+        className={className}
       />
     </div>
   );

--- a/app/_components/common/Input/PasswordInput.tsx
+++ b/app/_components/common/Input/PasswordInput.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Input from './Input';
 import Image from 'next/image';
 
+
 interface PasswordInputProps {
   value: string; // 입력값 (비밀번호)
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void; // 입력값 변경 시 호출되는 함수
@@ -10,6 +11,7 @@ interface PasswordInputProps {
   id?: string; // 입력 필드의 ID
   error?: boolean; // 에러 발생 여부
   errorMessage?: string; // 에러 메시지 (옵션)
+  className?: string;
 }
 
 const PasswordInput: React.FC<PasswordInputProps> = ({
@@ -20,6 +22,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
   id,
   error,
   errorMessage,
+  className,
 }) => {
   const [isPasswordVisible, setPasswordVisible] = useState<boolean>(false);
 
@@ -38,6 +41,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
         id={id}
         type={isPasswordVisible ? 'text' : 'password'}
         error={error}
+        className={className}
         rightIcon={
           <button
             type="button"

--- a/app/_components/login/LoginForm.tsx
+++ b/app/_components/login/LoginForm.tsx
@@ -89,9 +89,9 @@ const LoginForm = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen text-text-primary p-8">
-      <h1 className="text-4xl font-medium mb-10">로그인</h1>
-      <form onSubmit={handleSubmit} className="w-full max-w-md rounded-lg shadow-lg p-8">
+    <div className="flex flex-col items-center justify-center min-h-screen w-full tablet:max-w-[46rem]  text-text-primary py-8">
+      <h1 className="text-2xl pc:text-4xl font-medium mb-6">로그인</h1>
+      <form onSubmit={handleSubmit} className="w-full p-8 flex flex-col gap-4">
         <EmailInput
           label="이메일"
           value={email}
@@ -103,6 +103,7 @@ const LoginForm = () => {
           onBlur={() => handleBlur('email')}
           error={!!emailError}
           errorMessage={emailError}
+          className="h-[4.4rem] tablet:h-[4.8rem]"
         />
         <PasswordInput
           value={password}
@@ -114,9 +115,10 @@ const LoginForm = () => {
           onBlur={() => handleBlur('password')}
           error={!!passwordError}
           errorMessage={passwordError}
+          className="h-[4.4rem] tablet:h-[4.8rem]"
         />
-        {formError && <p className="text-status-danger text-[1rem] mt-2">{formError}</p>}
-        <div className="text-right text-[1rem] text-brand-primary mb-4">
+        {formError && <p className="text-status-danger font-medium text-[1.4rem]">{formError}</p>}
+        <div className="text-right font-medium text-[1.4rem] tablet:text-[1.6rem] text-brand-primary">
           <Link href="/forgot-password" className="hover:underline">비밀번호를 잊으셨나요?</Link>
         </div>
         <Button
@@ -124,17 +126,19 @@ const LoginForm = () => {
           variant="default"
           icon="none"
           round="xl"
-          className={`w-full h-12 text-[1rem] hover:bg-brand-primary text-text-inverse font-medium ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+          className={`mt-[3rem] w-full h-[4.7rem] font-semibold text-[1.6rem] hover:bg-brand-primary text-text-inverse  ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
           disabled={isLoading}
         >
           {isLoading ? '로그인 중...' : '로그인'}
         </Button>
       </form>
-      <div className="mt-8 text-[1rem] font-medium text-text-primary">
+      <div className="mt-2 text-[1.4rem] tablet:text-[1.6rem] font-medium text-text-primary">
         아직 계정이 없으신가요?{' '}
-        <Link href="/signUp" className="text-brand-primary hover:underline">가입하기</Link>
+        <Link href="/signUp" className="ml-4 text-brand-primary hover:underline">가입하기</Link>
       </div>
-      <SimpleLogin />
+      <div className="mt-6 ">
+      <SimpleLogin/>
+      </div>
     </div>
   );
 };

--- a/app/_components/login/SimpleLogin.tsx
+++ b/app/_components/login/SimpleLogin.tsx
@@ -5,19 +5,19 @@ import Image from 'next/image';
 
 const SimpleLogin = () => {
   return (
-    <div className="flex flex-col items-center mt-1 w-full max-w-[28.8rem]">
+    <div className="flex flex-col items-center h-auto mt-[2rem] w-[34.3rem] tablet:w-[46rem]">
       <div className="flex items-center mb-4 w-full">
         <div className="flex-grow border-t border-border-primary"></div>
-        <span className="px-4 text-text-inverse">OR</span>
+        <span className="px-[3rem] font-medium text-[1.6rem] tablet:font-normal text-text-inverse">OR</span>
         <div className="flex-grow border-t border-border-primary"></div>
       </div>
       <div className="flex items-center justify-between w-full">
-        <p className="text-[1rem] font-medium text-text-inverse">간편 로그인하기</p>
+        <p className="text-[1.6rem] font-medium text-text-inverse">간편 로그인하기</p>
         <div className="flex space-x-4">
-          <button className="flex items-center justify-center w-[2.65rem] h-[2.65rem]  rounded-full shadow-md">
+          <button className="flex items-center justify-center w-[4.2rem] h-[4.2rem]  rounded-full shadow-md">
             <Image src="/images/google.png" alt="Google Login" width={42} height={42} />
           </button>
-          <button className="flex items-center justify-center w-[2.65rem] h-[2.65rem]  rounded-full shadow-md">
+          <button className="flex items-center justify-center w-[4.2em] h-[4.2rem]  rounded-full shadow-md">
             <Image src="/images/kakaotalk.png" alt="Kakao Login" width={42} height={42} />
           </button>
         </div>

--- a/app/_components/signup/signupForm.tsx
+++ b/app/_components/signup/signupForm.tsx
@@ -109,9 +109,9 @@ const SignUpForm = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen text-text-primary p-8">
-      <h1 className="text-4xl font-medium my-10">회원가입</h1>
-      <form onSubmit={handleSubmit} className="w-full max-w-md rounded-lg shadow-lg bg-dark-light p-8 space-y-6">
+    <div className="flex flex-col w-[34.3rem] tablet:w-[46rem] items-center mt-4 min-h-screen text-text-primary py-8 ">
+      <h1 className="text-2xl font-medium pc:text-4xl mt-[4rem] mb-10">회원가입</h1>
+      <form onSubmit={handleSubmit} className="w-full space-y-8">
       <Input
           label="이름"
           value={nickname}
@@ -120,6 +120,8 @@ const SignUpForm = () => {
           onBlur={() => handleBlur('nickname')}
           error={!!errors.nickname}
           errorMessage={errors.nickname}
+          className=" h-[4.4rem] tablet:h-[4.8rem]"
+
         />
         <EmailInput
           label="이메일"
@@ -129,6 +131,7 @@ const SignUpForm = () => {
           onBlur={() => handleBlur('email')}
           error={!!errors.email}
           errorMessage={errors.email}
+          className="h-[4.4rem] tablet:h-[4.8rem]"
         />
         
         <PasswordInput
@@ -138,6 +141,7 @@ const SignUpForm = () => {
           onBlur={() => handleBlur('password')}
           error={!!errors.password}
           errorMessage={errors.password}
+          className="h-[4.4rem] tablet:h-[4.8rem]"
         />
         <PasswordInput
           value={confirmPassword}
@@ -146,13 +150,17 @@ const SignUpForm = () => {
           onBlur={() => handleBlur('confirmPassword')}
           error={!!errors.confirmPassword}
           errorMessage={errors.confirmPassword}
+          className="h-[4.4rem] tablet:h-[4.8rem]"
         />
-        {errors.general && <p className="text-status-danger text-sm">{errors.general}</p>}
-        <Button size="large" className="w-full h-12 bg-brand-primary rounded-xl text-text-inverse font-bold">
+        {errors.general && <p className="text-status-danger text-[1.4rem] font-medium">{errors.general}</p>}
+        </form>
+        <div className="mt-[3rem] tablet:mt-[4rem] w-full">
+        <Button size="large" className="w-full h-[4.7rem] bg-brand-primary  text-text-inverse font-semibold text-[1.6rem]">
           회원가입
         </Button>
-      </form>
-      <div className="mt-8 text-center">
+        </div>
+      
+      <div className="mt-5 text-center">
         <SimpleLogin />
       </div>
     </div>


### PR DESCRIPTION
## 📄 작업 내용 요약
이메일, 비밀번호 Input에 className 추가
입력필드 크기 사용자가 설정 할 수 있게 변경
로그인, 간단 로그인, 회원가입 페이지 반응형 작업
실수로 dev에서 작업해 버려서 파일 꼬여서 시간이 좀 걸렸습니다....

<img width="200" alt="스크린샷 2025-02-20 오후 11 48 21" src="https://github.com/user-attachments/assets/17d64883-8236-42c3-ae8c-4f4f2a0fa442" />
<img width="200" alt="스크린샷 2025-02-20 오후 11 48 10" src="https://github.com/user-attachments/assets/a9508052-ed2e-42d0-8283-9f044f269aa3" />

<img width="200" alt="스크린샷 2025-02-20 오후 11 44 48" src="https://github.com/user-attachments/assets/bcaaf68a-4b24-4668-8c74-d4d928779456" />

<img width="200" alt="스크린샷 2025-02-20 오후 11 47 37" src="https://github.com/user-attachments/assets/1a3d2f88-6abe-478d-8fa8-f5e6fdbd9e95" />

#10 # 📎 Issue 번호

<!-- closed #번호 -->
