### PR TITLE
feat/30-전반적인 오류 수정

### DIFF
--- a/app/_components/TeamPage/EditTeam.tsx
+++ b/app/_components/TeamPage/EditTeam.tsx
@@ -72,7 +72,6 @@ export default function EditTeam({ teamImg, teamName, teamId }: EditTeamProps) {
     } finally {
       setIsSubmitting(false);
       router.push(`/team/${teamId}`);
-      window.location.reload();
     }
   };
 

--- a/app/_components/TeamPage/MemberCard.tsx
+++ b/app/_components/TeamPage/MemberCard.tsx
@@ -50,7 +50,7 @@ export default function MemberCard({
         </div>
         <div className="flex flex-col">
           <div className="flex items-center gap-[0.5rem]">
-            <div className="max-w-[calc(100%-1.6rem)] break-words text-[1.4rem] text-text-primary">
+            <div className="break-words text-[1.4rem] text-text-primary">
               {name}
             </div>
             {role === 'ADMIN' && (

--- a/app/_components/common/Input/Input.tsx
+++ b/app/_components/common/Input/Input.tsx
@@ -78,10 +78,8 @@ const Input: React.FC<InputProps> = ({
           value={inputValue}
           onChange={handleChange}
           placeholder={placeholder}
-          className={`w-full rounded-[1.2rem] border-[0.1rem] bg-background-secondary px-[1.6rem] text-[1.6rem] text-text-primary placeholder:text-text-default focus:border-brand-primary focus:outline-none 
-            ${finalError ? 'border-status-danger focus:border-status-danger' : 'border-border-primary focus:border-interaction-hover'} 
-            ${rightIcon ? 'pr-[4.8rem]' : ''} 
-            ${className}`} />
+          className={`w-full rounded-[1.2rem] border-[0.1rem] bg-background-secondary px-[1.6rem] text-[1.6rem] text-text-primary placeholder:text-text-default focus:border-brand-primary focus:outline-none ${finalError ? 'border-status-danger focus:border-status-danger' : 'border-border-primary focus:border-interaction-hover'} ${rightIcon ? 'pr-[4.8rem]' : ''} ${className}`}
+        />
 
         {/* 오른쪽 아이콘 */}
         {rightIcon && (

--- a/app/_components/layout/Header/GnbButton.tsx
+++ b/app/_components/layout/Header/GnbButton.tsx
@@ -1,23 +1,13 @@
-// 'use client';
-
 import Image from 'next/image';
-// import { useState } from 'react';
-
 import gnbMenu from '@icons/gnb-menu.svg';
-// import Sidebar from '@/_components/common/Sidebar';
 
 const GnbButton = () => {
-  // const [isSidebarOpen, setIsSidebarOpen ] = useState(false)
-  
   return (
     <>
       <button
         type="button"
-        // onClick={() => setIsSidebarOpen(true)}
-        className="flex items-center justify-center p-1 rounded-md"
+        className="flex items-center justify-center rounded-md p-1"
         aria-label="메뉴 열기"
-        // aria-expanded={isSidebarOpen}
-        // aria-controls="mobile-sidebar"
       >
         <Image
           src={gnbMenu}
@@ -28,11 +18,6 @@ const GnbButton = () => {
           className="cursor-pointer"
         />
       </button>
-      {/* <Sidebar 
-        isOpen={isSidebarOpen} 
-        onClose={() => setIsSidebarOpen(false)}
-        id="mobile-sidebar"
-      /> */}
     </>
   );
 };

--- a/app/_components/layout/Header/TeamSelector.tsx
+++ b/app/_components/layout/Header/TeamSelector.tsx
@@ -45,8 +45,10 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
               aria-expanded={isOpen}
               aria-haspopup="true"
             >
-              <div className="flex items-center justify-center gap-2">
-                <span>{selectedTeam}</span>
+              <div className="flex max-w-[16rem] items-center justify-center gap-2 overflow-hidden">
+                <span className="block flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
+                  {selectedTeam}
+                </span>
                 <Image
                   src={toggle}
                   alt="토글 아이콘"
@@ -59,7 +61,7 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
             </Dropdown.Button>
             <Dropdown.Menu
               isOpen={isOpen}
-              boxClass="w-[22rem] top-[4rem] p-4 flex flex-col gap-2 items-center shadow-2xl"
+              boxClass="w-[22rem] top-[4rem] p-4 flex flex-col gap-2 shadow-2xl"
             >
               {userData?.memberships.map((membership) => (
                 <Link
@@ -86,7 +88,7 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
                         className="size-[3.2rem] rounded-xl object-cover"
                       />
                       <span
-                        className="overflow-hidden text-ellipsis whitespace-nowrap font-medium"
+                        className="w-full max-w-[12rem] overflow-hidden text-ellipsis whitespace-nowrap font-medium"
                         title={membership.group.name}
                       >
                         {membership.group.name}

--- a/app/_components/modal/AddTaskListModal.tsx
+++ b/app/_components/modal/AddTaskListModal.tsx
@@ -2,7 +2,6 @@
 
 import { Modal } from '../common/Modal';
 import Button from '../common/Button';
-import Input from '../common/Input/Input';
 import { useState } from 'react';
 import { createTaskList } from '@/_lib/api/tasklist-api';
 
@@ -39,9 +38,13 @@ export default function AddTaskListModal({
 
   return (
     <div>
-      <Modal isOpen={isOpenModal} onClose={handleCloseModal} className="">
+      <Modal
+        isOpen={isOpenModal}
+        onClose={handleCloseModal}
+        className="px-[3rem]"
+      >
         <Modal.CloseButton onClose={handleCloseModal} className="mr-[1.6rem]" />
-        <div className="mb-[1.6rem] flex flex-col gap-[0.8rem]">
+        <div className="mb-[1.6rem] flex w-full flex-col gap-[0.8rem]">
           <Modal.Title
             title="새로운 목록 추가"
             className="mt-[4.8rem] flex flex-col"
@@ -52,25 +55,27 @@ export default function AddTaskListModal({
             목록별 할 일을 만들 수 있습니다.
           </p>
         </div>
-        <div className="mb-[2.4rem] mt-[2rem] flex flex-col items-start">
-          <span className="text-[1.6rem] font-medium leading-[1.9rem]">
-            목록 이름
-          </span>
-          <Input
-            className="h-[4rem] w-full"
-            placeholder="목록 이름을 입력해주세요"
-            onChange={handleInputChange}
-          />
-        </div>
+        <div className="w-[28rem]">
+          <div className="mb-[2.4rem] mt-[2rem] flex flex-col items-start gap-[0.8rem]">
+            <span className="text-[1.6rem] font-medium leading-[1.9rem]">
+              목록 이름
+            </span>
+            <input
+              placeholder="목록 이름을 입력해주세요"
+              onChange={handleInputChange}
+              className="h-[4rem] w-full rounded-[1.2rem] border-[0.1rem] border-border-primary bg-background-secondary px-[1.6rem] text-[1.6rem] text-text-primary placeholder:text-text-default focus:border-brand-primary focus:outline-none"
+            />
+          </div>
 
-        <Button
-          size="modal-medium"
-          round="xl"
-          className="mb-[3.2rem] w-[24.4rem]"
-          onClick={handleCreate}
-        >
-          만들기
-        </Button>
+          <Button
+            size="modal-medium"
+            round="xl"
+            className="mb-[3.2rem]"
+            onClick={handleCreate}
+          >
+            만들기
+          </Button>
+        </div>
       </Modal>
     </div>
   );

--- a/app/_components/modal/KickUserModal.tsx
+++ b/app/_components/modal/KickUserModal.tsx
@@ -39,8 +39,8 @@ export default function DeleteUserModal({
           <Image src={AlertImg} alt="경고 아이콘" width={24} height={24} />
           <div className="mb-[2.4rem]">
             <Modal.Title
-              title={`정말 '${name}' 님을 팀에서 추방하시겠습니까?`}
-              className="mb-[0.8rem] flex flex-col"
+              title={`정말 '${name}' 님을\n팀에서 추방하시겠습니까?`}
+              className="mb-[0.8rem] flex flex-col whitespace-pre-line"
             />
           </div>
         </div>


### PR DESCRIPTION
## 📄 작업 내용 요약
- 할 일 목록 생성 모달창의 인풋컴포넌트에서 계속 디자인 오류가 나서 인풋 컴포넌트 빼고 자체 디자인했습니다
- 헤더의 팀 목록 드롭다운에 오버플로우된 값이 들어갔을 경우, 디자인 오류가 생겨 오버플로우된 부분은 숨김처리하는 식으로 디자인 수정했습니다.
- 팀 멤버 추방 모달에 텍스트 디자인 살짝 수정했습니다.
- 불필요한 주석 제거했습니다.

![image](https://github.com/user-attachments/assets/c3bc27bb-4199-48b6-9865-94deace351cb)
![image](https://github.com/user-attachments/assets/c1d8fbe3-c190-4985-a27e-dab3fea1b41c)


## 📎 Issue 번호
#30 

<!-- closed #번호 -->
closed #30 
